### PR TITLE
Adds freemode, disable featureinfo on active

### DIFF
--- a/scss/draw-freemode.scss
+++ b/scss/draw-freemode.scss
@@ -1,0 +1,60 @@
+.switch {     
+  position: relative;      
+  display: inline-block;      
+  width: 3.8rem;      
+  height: 2rem;    
+  overflow: hidden;
+}
+.slider {  
+  position: absolute;  
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+  left: 0; 
+  background-color: #dbdbdb;  
+  -webkit-transition: .4s;  
+  transition: .4s;
+}
+.freehand-icon {
+  position: absolute;
+  left: .4rem;
+  bottom: .26rem;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+input:checked + .slider {
+  background-color: #1096f5;
+}
+input:checked + .slider>.freehand-icon {
+  -webkit-transform: translateX(100%);
+  -ms-transform: translateX(100%);
+  transform: translateX(100%);
+}
+.slider.round {
+  border-radius: 34px;
+}
+.freehand-icon{
+  border-radius: 50%;
+}
+.o-icon-pencil{
+  height: 1rem !important;
+  width: 1rem !important;
+  padding: .2rem !important;
+}
+@media screen and (max-width: 500px) {
+  .o-icon-pencil {
+    height: .7rem !important;
+    width: .7rem !important;
+    padding: .17rem !important;
+  }
+  .freehand-icon {
+    left: .3rem;
+    bottom: 0.12rem;
+  }
+  .switch {     
+    width: 2.8rem;
+    height: 1.3rem;
+    overflow: inherit;
+  }
+}

--- a/scss/draw-plugin.scss
+++ b/scss/draw-plugin.scss
@@ -13,7 +13,7 @@
   padding: 0 .5rem; 
   bottom: 1em;
   left: 50%;
-  transition: all 0.6s ease-in;
+  transition: all 0.2s ease-in;
   -webkit-box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   -ms-transform: translate(-50%, 0);

--- a/scss/draw-plugin.scss
+++ b/scss/draw-plugin.scss
@@ -13,7 +13,6 @@
   padding: 0 .5rem; 
   bottom: 1em;
   left: 50%;
-  transition: all 0.2s ease-in;
   -webkit-box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   -ms-transform: translate(-50%, 0);

--- a/scss/draw-plugin.scss
+++ b/scss/draw-plugin.scss
@@ -1,4 +1,5 @@
-#o-draw-toolbar {
+@import 'draw-freemode.scss';
+.o-draw-toolbar {
   background-color: #fff;
   color: #000;
   position: absolute;
@@ -12,12 +13,16 @@
   padding: 0 .5rem; 
   bottom: 1em;
   left: 50%;
+  transition: all 0.6s ease-in;
   -webkit-box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.45);
   -ms-transform: translate(-50%, 0);
   -webkit-transform: translate(-50%, 0);
   transform: translate(-50%, 0);
 
+}
+
+#o-draw-toolbar{
   svg {
     height: 2em;
     width: 2em;
@@ -36,5 +41,12 @@
       width: 2em;
     }
   }
+}
 
+.draw-toolbar-hide {
+  bottom: 80%;
+  left: 80%;
+  opacity: 0;
+  visibility: hidden;
+  transition: none;
 }

--- a/src/draw/drawhandler.js
+++ b/src/draw/drawhandler.js
@@ -60,11 +60,10 @@ function setActive(drawType) {
 }
 
 function onTextEnd(feature, textVal) {
-  //Remove the feature if no text is set
-  if(textVal === ""){
+  // Remove the feature if no text is set
+  if (textVal === '') {
     drawLayer.getFeatureStore().removeFeature(feature);
-  }
-  else{ 
+  } else {
     const text = defaultDrawStyle.text;
     text.text.text = textVal;
     const textStyle = Style.createStyleRule([text]);
@@ -89,7 +88,7 @@ function promptText(feature) {
   const editableText = $('#o-draw-input-text').val();
   document.getElementById('o-draw-input-text').focus();
   $('#o-draw-input-text').on('keyup', (e) => {
-    if (e.keyCode == 13) {
+    if (e.keyCode === 13) {
       $('#o-draw-save-text').trigger('click');
     }
   });
@@ -100,7 +99,7 @@ function promptText(feature) {
     e.preventDefault();
     onTextEnd(feature, textVal);
   });
-  $('.o-modal-screen, .o-close-button').on('click', e => {
+  $('.o-modal-screen, .o-close-button').on('click', (e) => {
     $('#o-draw-save-text').blur();
     e.preventDefault();
     onTextEnd(feature, editableText);
@@ -146,7 +145,7 @@ function setDraw(drawType) {
   draw = new Origo.ol.interaction.Draw({
     source: drawLayer.getFeatureStore(),
     type: geometryType,
-    freehand : $("#toggle-freemode").is(':checked')
+    freehand: $('#toggle-freemode').is(':checked')
   });
   map.addInteraction(draw);
   dispatcher.emitChangeDraw(drawType, true);
@@ -259,7 +258,7 @@ function runPolyFill() {
   }
 }
 
-const getActiveTool = () => activeTool
+const getActiveTool = () => activeTool;
 
 const init = function init(optOptions) {
   runPolyFill();

--- a/src/draw/drawtoolbar.js
+++ b/src/draw/drawtoolbar.js
@@ -11,35 +11,48 @@ let $drawDelete;
 let $drawClose;
 let drawTools;
 let target;
+let viewer;
+let freemodeToggle = `
+  <label title='On/off för frihandläge (Linje och polygon)' class="switch">
+      <input id='toggle-freemode' type="checkbox" style="opacity:0;">
+      <span class="slider round">
+          <span class="freehand-icon">
+              <svg class="o-icon-pencil">
+                  <use xlink:href="#fa-pencil"></use>
+              </svg>
+          </span>
+      </span>
+  </label>`;
 
 function render() {
-  $(`#${target}`).append("<div id='o-draw-toolbar' class='o-control o-toolbar o-padding-horizontal-8 o-rounded-top o-hidden'>" +
-    "<button id='o-draw-point' class='o-btn-3' type='button' name='button'>" +
+  $(`#${target}`).append("<div id='o-draw-toolbar' class='o-draw-toolbar o-control o-toolbar o-padding-horizontal-8 o-rounded-top draw-toolbar-hide'>" +
+    `${freemodeToggle}`+
+    "<button title='Punkt' id='o-draw-point' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-fa-map-marker'>" +
     "<use xlink:href='#fa-map-marker'></use>" +
     '</svg>' +
     '</button>' +
-    "<button id='o-draw-polygon' class='o-btn-3' type='button' name='button'>" +
+    "<button title='Polygon' id='o-draw-polygon' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-minicons-square-vector'>" +
     "<use xlink:href='#minicons-square-vector'></use>" +
     '</svg>' +
     '</button>' +
-    "<button id='o-draw-polyline' class='o-btn-3' type='button' name='button'>" +
+    "<button title='Linje' id='o-draw-polyline' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-minicons-line-vector'>" +
     "<use xlink:href='#minicons-line-vector'></use>" +
     '</svg>' +
     '</button>' +
-    "<button id='o-draw-text' class='o-btn-3' type='button' name='button'>" +
+    "<button title='Text' id='o-draw-text' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-fa-font'>" +
     "<use xlink:href='#fa-font'></use>" +
     '</svg>' +
     '</button>' +
-    "<button id='o-draw-delete' class='o-btn-3' type='button' name='button'>" +
+    "<button title='Ta bort' id='o-draw-delete' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-fa-trash'>" +
     "<use xlink:href='#fa-trash'></use>" +
     '</svg>' +
     '</button>' +
-    "<button id='o-draw-close' class='o-btn-3' type='button' name='button'>" +
+    "<button title='Stäng' id='o-draw-close' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-fa-times'>" +
     "<use xlink:href='#fa-times'></use>" +
     '</svg>' +
@@ -60,6 +73,12 @@ function render() {
 }
 
 function bindUIActions() {
+  $('#toggle-freemode').on("click", (e) => {
+    //deactivate current tool and reactivate it again with freemode
+    let active = drawHandler.getActiveTool()
+    dispatcher.emitToggleDraw(active);
+    dispatcher.emitToggleDraw(active);
+  });
   $drawDelete.on('click', (e) => {
     dispatcher.emitToggleDraw('delete');
     $drawDelete.blur();
@@ -100,9 +119,11 @@ function bindUIActions() {
 
 function setActive(state) {
   if (state === true) {
-    $('#o-draw-toolbar').removeClass('o-hidden');
+    viewer.dispatch('toggleClickInteraction', {name: 'featureinfo',active:false});
+    $('#o-draw-toolbar').removeClass('draw-toolbar-hide');
   } else {
-    $('#o-draw-toolbar').addClass('o-hidden');
+    viewer.dispatch('toggleClickInteraction', {name: 'featureinfo',active:true});
+    $('#o-draw-toolbar').addClass('draw-toolbar-hide');
   }
 }
 
@@ -147,7 +168,7 @@ function restoreState(params) {
 
 function init(optOptions) {
   const options = optOptions || {};
-  const viewer = options.viewer;
+  viewer = options.viewer;
   target = `${viewer.getMain().getId()}`;
   drawHandler.init(options);
   render();

--- a/src/draw/drawtoolbar.js
+++ b/src/draw/drawtoolbar.js
@@ -12,7 +12,7 @@ let $drawClose;
 let drawTools;
 let target;
 let viewer;
-let freemodeToggle = `
+const freemodeToggle = `
   <label title='On/off för frihandläge (Linje och polygon)' class="switch">
       <input id='toggle-freemode' type="checkbox" style="opacity:0;">
       <span class="slider round">
@@ -26,7 +26,7 @@ let freemodeToggle = `
 
 function render() {
   $(`#${target}`).append("<div id='o-draw-toolbar' class='o-draw-toolbar o-control o-toolbar o-padding-horizontal-8 o-rounded-top draw-toolbar-hide'>" +
-    `${freemodeToggle}`+
+    `${freemodeToggle}` +
     "<button title='Punkt' id='o-draw-point' class='o-btn-3' type='button' name='button'>" +
     "<svg class='o-icon-fa-map-marker'>" +
     "<use xlink:href='#fa-map-marker'></use>" +
@@ -73,9 +73,9 @@ function render() {
 }
 
 function bindUIActions() {
-  $('#toggle-freemode').on("click", (e) => {
-    //deactivate current tool and reactivate it again with freemode
-    let active = drawHandler.getActiveTool()
+  $('#toggle-freemode').on('click', () => {
+    // deactivate current tool and reactivate it again with freemode
+    const active = drawHandler.getActiveTool();
     dispatcher.emitToggleDraw(active);
     dispatcher.emitToggleDraw(active);
   });
@@ -119,10 +119,10 @@ function bindUIActions() {
 
 function setActive(state) {
   if (state === true) {
-    viewer.dispatch('toggleClickInteraction', {name: 'featureinfo',active:false});
+    viewer.dispatch('toggleClickInteraction', { name: 'featureinfo', active: false });
     $('#o-draw-toolbar').removeClass('draw-toolbar-hide');
   } else {
-    viewer.dispatch('toggleClickInteraction', {name: 'featureinfo',active:true});
+    viewer.dispatch('toggleClickInteraction', { name: 'featureinfo', active: true });
     $('#o-draw-toolbar').addClass('draw-toolbar-hide');
   }
 }

--- a/src/draw/textform.js
+++ b/src/draw/textform.js
@@ -31,7 +31,7 @@ const createForm = function createForm(options) {
     cls: 'o-form-save'
   });
   const content = `${input}<br><br>${saveWrapper}`;
-  const form = createElement('form', content);
+  const form = createElement('div', content);
   return form;
 };
 


### PR DESCRIPTION
This adds a toggle-button to toggle between drawing lines and polygons with freehand-mode or not, and disables featureinfo and pinning while the drawtool is active.  
Also as stated in a comment on commit, this fixes bugs related to adding text-type and adds tooltips.

![freemode-draw](https://user-images.githubusercontent.com/34093582/65322549-73c7b500-dba7-11e9-94e5-07125781d3c6.PNG)
