### PR TITLE
Stylewindow

### DIFF
--- a/scss/draw-plugin.scss
+++ b/scss/draw-plugin.scss
@@ -8,5 +8,49 @@
   -webkit-transform: translate(-50%, 0);
   transform: translate(-50%, 0);
   z-index: 10;
+}
 
+#o-draw-stylewindow {
+  font-family: Arial,sans-serif;
+  width: 250px;
+  position:absolute;
+  right: 1rem;
+  -ms-transform: translate(0, -50%);
+  -webkit-transform: translate(0, -50%);
+  transform: translate(0, -50%);
+  top:50%;
+  height: calc(100% - 9rem);
+}
+
+#o-draw-stylewindow input[type="radio"] {
+  display:none;
+}
+
+#o-draw-stylewindow input[type="radio"] + label span {
+  display:inline-block;
+  width:24px;
+  height:24px;
+  vertical-align:middle;
+  cursor:pointer;
+  -moz-border-radius:  50%;
+  border-radius:  50%;
+  box-shadow: 0 0 0 2px white, 0 0 0 4px white;
+}
+
+#o-draw-stylewindow input[type="radio"]:checked + label span{
+  box-shadow: 0 0 0 2px white, 0 0 0 4px #ababab;
+}
+
+#o-draw-stylewindow input[type="radio"] ~ label span:hover {
+  box-shadow: 0 0 0 2px white, 0 0 0 4px #cdcdcd;
+}
+
+#o-draw-stylewindow input[type="radio"] ~ label {
+  display:inline-block;
+  vertical-align:middle;
+  padding:5px;
+}
+
+#o-draw-stylewindow ul li {
+  float:left;
 }

--- a/src/draw.js
+++ b/src/draw.js
@@ -1,11 +1,12 @@
 import Origo from 'Origo';
 import drawtoolbar from './draw/drawtoolbar';
+import { Stylewindow } from './draw/stylewindow';
 import dispatcher from './draw/drawdispatcher';
 
 const Draw = function Draw(options = {}) {
   const {
     buttonText = 'Rita',
-    drawTools
+    palette
   } = options;
 
   const icon = '#fa-pencil';
@@ -40,7 +41,9 @@ const Draw = function Draw(options = {}) {
         viewer,
         options
       });
+      const stylewindow = Stylewindow({ target: viewer.getMain().getId(), palette });
       drawtoolbar.restoreState(viewer.getUrlParams());
+      this.addComponent(stylewindow);
       this.addComponent(menuItem);
       this.render();
     },

--- a/src/draw/drawdispatcher.js
+++ b/src/draw/drawdispatcher.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import drawHandler from './drawhandler';
 
 function emitToggleDraw(tool, optOptions) {
   const options = optOptions || {};
@@ -26,6 +27,7 @@ function emitEnableDrawInteraction() {
 }
 
 function emitDisableDrawInteraction() {
+  drawHandler.getSelection().clear();
   $('.o-map').first().trigger({
     type: 'enableInteraction',
     interaction: 'featureinfo'

--- a/src/draw/drawhandler.js
+++ b/src/draw/drawhandler.js
@@ -242,6 +242,9 @@ function restoreState(state) {
       if (feature.get('style')) {
         const featureStyle = getStylewindowStyle(feature, feature.get('style'));
         feature.setStyle(featureStyle);
+      } else {
+        const featureStyle = getStylewindowStyle(feature);
+        feature.setStyle(featureStyle);
       }
     });
   }
@@ -314,7 +317,7 @@ const init = function init(optOptions) {
 
   map = options.viewer.getMap();
 
-  annotationField = options.annotation || 'annotation';
+  annotationField = options.annotation || 'annonation';
   activeTool = undefined;
 
   $(document).on('toggleDraw', toggleDraw);

--- a/src/draw/drawhandler.js
+++ b/src/draw/drawhandler.js
@@ -121,7 +121,7 @@ function onDrawEnd(evt) {
   }
   enableDoubleClickZoom(evt);
   if (drawLayer) {
-    const featureStyle = getStylewindowStyle(evt.feature, annotationField);
+    const featureStyle = getStylewindowStyle(evt.feature);
     evt.feature.setStyle(featureStyle);
   }
 }
@@ -168,7 +168,7 @@ function onSelectAdd(e) {
   let feature;
   if (e.target) {
     feature = e.target.item(0);
-    const featureStyle = feature.getStyle();
+    const featureStyle = feature.getStyle() || Style.createStyleRule(defaultDrawStyle.draw[1]);
     featureStyle.push(selectionStyle);
     feature.setStyle(featureStyle);
     updateStylewindow(feature);
@@ -237,7 +237,11 @@ function restoreState(state) {
     source.addFeatures(state.features);
     source.getFeatures().forEach((feature) => {
       if (feature.get(annotationField)) {
-        onTextEnd(feature, feature.get(annotationField));
+        feature.set(annotationField, feature.get(annotationField));
+      }
+      if (feature.get('style')) {
+        const featureStyle = getStylewindowStyle(feature, feature.get('style'));
+        feature.setStyle(featureStyle);
       }
     });
   }

--- a/src/draw/drawtemplate.js
+++ b/src/draw/drawtemplate.js
@@ -23,6 +23,11 @@ export default `<div id="o-draw-toolbar" class="o-draw-toolbar o-toolbar o-toolb
         <use xlink:href="#ic_title_24px"></use>
       </svg>
     </button>
+    <button title="Stil" id="o-draw-style" class="icon-smaller medium round light" type="button" name="button">
+      <svg class="icon">
+        <use xlink:href="#ic_palette_24px"></use>
+      </svg>
+    </button>
     <button title="Ta bort" id="o-draw-delete" class="icon-smaller medium round light" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_delete_24px"></use>

--- a/src/draw/drawtoolbar.js
+++ b/src/draw/drawtoolbar.js
@@ -9,6 +9,7 @@ let $drawPolygon;
 let $drawLineString;
 let $drawPoint;
 let $drawText;
+let $drawStyle;
 let $drawDelete;
 let $drawClose;
 let drawTools;
@@ -21,6 +22,7 @@ function render() {
   $drawLineString = $('#o-draw-polyline');
   $drawPoint = $('#o-draw-point');
   $drawText = $('#o-draw-text');
+  $drawStyle = $('#o-draw-style');
   $drawDelete = $('#o-draw-delete');
   $drawClose = $('#o-draw-close');
   drawTools = {
@@ -57,7 +59,15 @@ function bindUIActions() {
     $drawText.blur();
     e.preventDefault();
   });
+  $drawStyle.on('click', (e) => {
+    const stylewindowEl = document.getElementById('o-draw-stylewindow');
+    stylewindowEl.classList.toggle('hidden');
+    $drawStyle.blur();
+    e.preventDefault();
+  });
   $drawClose.on('click', (e) => {
+    const stylewindowEl = document.getElementById('o-draw-stylewindow');
+    stylewindowEl.classList.add('hidden');
     dispatcher.emitDisableDrawInteraction();
     $drawClose.blur();
     e.stopPropagation();

--- a/src/draw/styletemplate.js
+++ b/src/draw/styletemplate.js
@@ -1,9 +1,14 @@
-export default function styleTemplate(palette) {
+export default function styleTemplate(palette, swStyle) {
   const colorArray = palette;
   let fillHtml = '<div id="o-draw-style-fill" class="padding border-bottom"><div class="text-large text-align-center">Fyllning</div><div id="o-draw-style-fillColor"><ul>';
-
+  if (!colorArray.includes(swStyle.fillColor)) {
+    colorArray.push(swStyle.fillColor);
+  }
+  if (!colorArray.includes(swStyle.strokeColor)) {
+    colorArray.push(swStyle.strokeColor);
+  }
   for (let i = 0; i < colorArray.length; i += 1) {
-    const checked = i === 0 ? ' checked=true' : '';
+    const checked = colorArray[i] === swStyle.fillColor ? ' checked=true' : '';
     fillHtml += `<li>
     <input type="radio" id="fillColorRadio${i}" name="fillColorRadio" value="${colorArray[i]}"${checked} />
     <label for="fillColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
@@ -11,7 +16,7 @@ export default function styleTemplate(palette) {
   }
 
   fillHtml += `</ul></div><div class="padding-smaller o-tooltip active">
-  <input id="o-draw-style-fillOpacitySlider" type="range" min="0.05" max="1" value="0.75" step="0.05">
+  <input id="o-draw-style-fillOpacitySlider" type="range" min="0.05" max="1" value="${swStyle.fillOpacity}" step="0.05">
   <div class="text-align-center">
     <span class="text-smaller float-left">5%</span>
     <span class="text-smaller">Opacitet</span>
@@ -21,7 +26,7 @@ export default function styleTemplate(palette) {
 
   let strokeHtml = '<div id="o-draw-style-stroke" class="padding border-bottom"><div class="text-large text-align-center">Kantlinje</div><div id="o-draw-style-strokeColor"><ul>';
   for (let i = 0; i < colorArray.length; i += 1) {
-    const checked = i === 1 ? ' checked=true' : '';
+    const checked = colorArray[i] === swStyle.strokeColor ? ' checked=true' : '';
     strokeHtml += `<li>
     <input type="radio" id="strokeColorRadio${i}" name="strokeColorRadio" value="${colorArray[i]}"${checked} />
     <label for="strokeColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
@@ -29,7 +34,7 @@ export default function styleTemplate(palette) {
   }
 
   strokeHtml += `</ul></div><div class="padding-smaller o-tooltip active">
-  <input id="o-draw-style-strokeOpacitySlider" type="range" min="0.05" max="1" value="1" step="0.05">
+  <input id="o-draw-style-strokeOpacitySlider" type="range" min="0.05" max="1" value="${swStyle.strokeOpacity}" step="0.05">
   <div class="text-align-center">
     <span class="text-smaller float-left">5%</span>
     <span class="text-smaller">Opacitet</span>
@@ -37,7 +42,7 @@ export default function styleTemplate(palette) {
   </div>
   </div>
   <div class="padding-smaller o-tooltip active">
-  <input id="o-draw-style-strokeWidthSlider" type="range" min="1" max="10" value="2" step="1">
+  <input id="o-draw-style-strokeWidthSlider" type="range" min="1" max="10" value="${swStyle.strokeWidth}" step="1">
   <div class="text-align-center">
     <span class="text-smaller float-left">1px</span>
     <span class="text-smaller">Linjebredd</span>
@@ -46,15 +51,15 @@ export default function styleTemplate(palette) {
   </div>
   <div class="padding-smaller o-tooltip active">
     <select id="o-draw-style-strokeType" class="small no-margin width-full">
-      <option value="line">Heldragen linje</option>
-      <option value="dash">Streckad linje</option>
-      <option value="point">Punktad linje</option>
-      <option value="dash-point">Streck-punkt-linje</option>
+      <option value="line"${swStyle.strokeType === 'line' ? ' selected' : ''}>Heldragen linje</option>
+      <option value="dash"${swStyle.strokeType === 'dash' ? ' selected' : ''}>Streckad linje</option>
+      <option value="point"${swStyle.strokeType === 'point' ? ' selected' : ''}>Punktad linje</option>
+      <option value="dash-point"${swStyle.strokeType === 'dash-point' ? ' selected' : ''}>Streck-punkt-linje</option>
     </select>
   </div></div>`;
 
   const pointHtml = `<div id="o-draw-style-point" class="padding border-bottom"><div class="text-large text-align-center">Punkt</div><div class="padding-smaller o-tooltip active">
-    <input id="o-draw-style-pointSizeSlider" type="range" min="1" max="50" value="10" step="1">
+    <input id="o-draw-style-pointSizeSlider" type="range" min="1" max="50" value="${swStyle.pointSize}" step="1">
     <div class="text-align-center">
       <span class="text-smaller float-left">1px</span>
       <span class="text-smaller">Punktstorlek</span>
@@ -63,17 +68,17 @@ export default function styleTemplate(palette) {
   </div>
   <div class="padding-smaller o-tooltip active">
     <select id="o-draw-style-pointType" class="small no-margin width-full">
-      <option value="circle">Cirkel</option>
-      <option value="x">Kryss</option>
-      <option value="cross">Kors</option>
-      <option value="star">Stjärna</option>
-      <option value="triangle">Triangel</option>
-      <option value="square">Kvadrat</option>
+      <option value="circle"${swStyle.pointType === 'circle' ? ' selected' : ''}>Cirkel</option>
+      <option value="x"${swStyle.pointType === 'x' ? ' selected' : ''}>Kryss</option>
+      <option value="cross"${swStyle.pointType === 'cross' ? ' selected' : ''}>Kors</option>
+      <option value="star"${swStyle.pointType === 'star' ? ' selected' : ''}>Stjärna</option>
+      <option value="triangle"${swStyle.pointType === 'triangle' ? ' selected' : ''}>Triangel</option>
+      <option value="square"${swStyle.pointType === 'square' ? ' selected' : ''}>Kvadrat</option>
     </select>
   </div></div>`;
 
   const textHtml = `<div id="o-draw-style-text" class="padding border-bottom"><div class="text-large text-align-center">Text</div><div class="padding-smaller o-tooltip active">
-    <input id="o-draw-style-textSizeSlider" type="range" min="8" max="128" value="20" step="1">
+    <input id="o-draw-style-textSizeSlider" type="range" min="8" max="128" value="${swStyle.textSize}" step="1">
     <div class="text-align-center">
       <span class="text-smaller float-left">8px</span>
       <span class="text-smaller">Textstorlek</span>
@@ -81,7 +86,7 @@ export default function styleTemplate(palette) {
     </div>
   </div>
   <div class="padding-smaller o-tooltip active">
-    <input id="o-draw-style-textString" class="small no-margin width-full" type="text">
+    <input id="o-draw-style-textString" class="small no-margin width-full" type="text" value="${swStyle.textString}">
   </div></div>`;
 
   return textHtml + pointHtml + fillHtml + strokeHtml;

--- a/src/draw/styletemplate.js
+++ b/src/draw/styletemplate.js
@@ -1,0 +1,88 @@
+export default function styleTemplate(palette) {
+  const colorArray = palette;
+  let fillHtml = '<div id="o-draw-style-fill" class="padding border-bottom"><div class="text-large text-align-center">Fyllning</div><div id="o-draw-style-fillColor"><ul>';
+
+  for (let i = 0; i < colorArray.length; i += 1) {
+    const checked = i === 0 ? ' checked=true' : '';
+    fillHtml += `<li>
+    <input type="radio" id="fillColorRadio${i}" name="fillColorRadio" value="${colorArray[i]}"${checked} />
+    <label for="fillColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
+    </li>`;
+  }
+
+  fillHtml += `</ul></div><div class="padding-smaller o-tooltip active">
+  <input id="o-draw-style-fillOpacitySlider" type="range" min="0.05" max="1" value="0.75" step="0.05">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">5%</span>
+    <span class="text-smaller">Opacitet</span>
+    <span class="text-smaller float-right">100%</span>
+  </div>
+  </div></div>`;
+
+  let strokeHtml = '<div id="o-draw-style-stroke" class="padding border-bottom"><div class="text-large text-align-center">Kantlinje</div><div id="o-draw-style-strokeColor"><ul>';
+  for (let i = 0; i < colorArray.length; i += 1) {
+    const checked = i === 1 ? ' checked=true' : '';
+    strokeHtml += `<li>
+    <input type="radio" id="strokeColorRadio${i}" name="strokeColorRadio" value="${colorArray[i]}"${checked} />
+    <label for="strokeColorRadio${i}"><span style="background:${colorArray[i]}"></span></label>
+    </li>`;
+  }
+
+  strokeHtml += `</ul></div><div class="padding-smaller o-tooltip active">
+  <input id="o-draw-style-strokeOpacitySlider" type="range" min="0.05" max="1" value="1" step="0.05">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">5%</span>
+    <span class="text-smaller">Opacitet</span>
+    <span class="text-smaller float-right">100%</span>
+  </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+  <input id="o-draw-style-strokeWidthSlider" type="range" min="1" max="10" value="2" step="1">
+  <div class="text-align-center">
+    <span class="text-smaller float-left">1px</span>
+    <span class="text-smaller">Linjebredd</span>
+    <span class="text-smaller float-right">10px</span>
+  </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <select id="o-draw-style-strokeType" class="small no-margin width-full">
+      <option value="line">Heldragen linje</option>
+      <option value="dash">Streckad linje</option>
+      <option value="point">Punktad linje</option>
+      <option value="dash-point">Streck-punkt-linje</option>
+    </select>
+  </div></div>`;
+
+  const pointHtml = `<div id="o-draw-style-point" class="padding border-bottom"><div class="text-large text-align-center">Punkt</div><div class="padding-smaller o-tooltip active">
+    <input id="o-draw-style-pointSizeSlider" type="range" min="1" max="50" value="10" step="1">
+    <div class="text-align-center">
+      <span class="text-smaller float-left">1px</span>
+      <span class="text-smaller">Punktstorlek</span>
+      <span class="text-smaller float-right">50px</span>
+    </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <select id="o-draw-style-pointType" class="small no-margin width-full">
+      <option value="circle">Cirkel</option>
+      <option value="x">Kryss</option>
+      <option value="cross">Kors</option>
+      <option value="star">Stjärna</option>
+      <option value="triangle">Triangel</option>
+      <option value="square">Kvadrat</option>
+    </select>
+  </div></div>`;
+
+  const textHtml = `<div id="o-draw-style-text" class="padding border-bottom"><div class="text-large text-align-center">Text</div><div class="padding-smaller o-tooltip active">
+    <input id="o-draw-style-textSizeSlider" type="range" min="8" max="128" value="20" step="1">
+    <div class="text-align-center">
+      <span class="text-smaller float-left">8px</span>
+      <span class="text-smaller">Textstorlek</span>
+      <span class="text-smaller float-right">128px</span>
+    </div>
+  </div>
+  <div class="padding-smaller o-tooltip active">
+    <input id="o-draw-style-textString" class="small no-margin width-full" type="text">
+  </div></div>`;
+
+  return textHtml + pointHtml + fillHtml + strokeHtml;
+}

--- a/src/draw/stylewindow.js
+++ b/src/draw/stylewindow.js
@@ -344,7 +344,7 @@ function Stylewindow(optOptions = {}) {
     palette = ['rgb(166,206,227)', 'rgb(31,120,180)', 'rgb(178,223,138)', 'rgb(51,160,44)', 'rgb(251,154,153)', 'rgb(227,26,28)', 'rgb(253,191,111)']
   } = optOptions;
 
-  annotationField = optOptions.annotation || 'annotation';
+  annotationField = optOptions.annotation || 'annonation';
   swStyle = Object.assign(swDefaults, optOptions.swDefaults);
 
   let stylewindowEl;

--- a/src/draw/stylewindow.js
+++ b/src/draw/stylewindow.js
@@ -1,0 +1,474 @@
+import Origo from 'Origo';
+import styleTemplate from './styletemplate';
+import drawHandler from './drawhandler';
+
+let fillColor;
+let fillColorArr;
+let fillOpacity;
+let strokeColor;
+let strokeColorArr;
+let strokeOpacity;
+let strokeWidth;
+let strokeType;
+let pointSize;
+let pointType;
+let textSize;
+let textString;
+let annotationField;
+const textFont = '"Helvetica Neue", Helvetica, Arial, sans-serif';
+
+function getStrokeType(lineDash) {
+  if (!lineDash) {
+    strokeType = 'line';
+  } else if (lineDash.length === 2 && lineDash[0] === lineDash[1]) {
+    strokeType = 'dash';
+  } else if (lineDash.length === 2 && lineDash[0] < lineDash[1]) {
+    strokeType = 'point';
+  } else if (lineDash.length === 4) {
+    strokeType = 'dash-point';
+  } else {
+    strokeType = 'line';
+  }
+  return strokeType;
+}
+
+function createRegularShape(type, size, fill, stroke) {
+  let style;
+  switch (type) {
+    case 'square':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          angle: Math.PI / 4
+        })
+      });
+      break;
+
+    case 'triangle':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.RegularShape({
+          fill,
+          stroke,
+          points: 3,
+          radius: size,
+          rotation: 0,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'star':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.RegularShape({
+          fill,
+          stroke,
+          points: 5,
+          radius: size,
+          radius2: size / 2.5,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'cross':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          radius2: 0,
+          angle: 0
+        })
+      });
+      break;
+
+    case 'x':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.RegularShape({
+          fill,
+          stroke,
+          points: 4,
+          radius: size,
+          radius2: 0,
+          angle: Math.PI / 4
+        })
+      });
+      break;
+
+    case 'circle':
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.Circle({
+          fill,
+          stroke,
+          radius: size
+        })
+      });
+      break;
+
+    default:
+      style = new Origo.ol.style.Style({
+        image: new Origo.ol.style.Circle({
+          fill,
+          stroke,
+          radius: size
+        })
+      });
+  }
+  return style;
+}
+
+function rgbToArray(colorString, opacity = 1) {
+  const colorArray = colorString.replace(/[^\d,.]/g, '').split(',');
+  colorArray[3] = opacity;
+  return colorArray;
+}
+
+function setFillColor(color) {
+  fillColor = color;
+  fillColorArr = rgbToArray(fillColor, fillOpacity);
+}
+
+function setStrokeColor(color) {
+  strokeColor = color;
+  strokeColorArr = rgbToArray(strokeColor, strokeOpacity);
+}
+
+function restoreStylewindow() {
+  document.getElementById('o-draw-style-fill').classList.remove('hidden');
+  document.getElementById('o-draw-style-stroke').classList.remove('hidden');
+  document.getElementById('o-draw-style-point').classList.remove('hidden');
+  document.getElementById('o-draw-style-text').classList.remove('hidden');
+}
+
+function updateStylewindow(feature) {
+  let geometryType = feature.getGeometry().getType();
+  if (feature.get(annotationField)) {
+    geometryType = 'TextPoint';
+  }
+  switch (geometryType) {
+    case 'LineString':
+    case 'MultiLineString':
+      document.getElementById('o-draw-style-fill').classList.add('hidden');
+      document.getElementById('o-draw-style-point').classList.add('hidden');
+      document.getElementById('o-draw-style-text').classList.add('hidden');
+      break;
+    case 'Polygon':
+    case 'MultiPolygon':
+      document.getElementById('o-draw-style-point').classList.add('hidden');
+      document.getElementById('o-draw-style-text').classList.add('hidden');
+      break;
+    case 'Point':
+    case 'MultiPoint':
+      document.getElementById('o-draw-style-text').classList.add('hidden');
+      break;
+    case 'TextPoint':
+      document.getElementById('o-draw-style-stroke').classList.add('hidden');
+      document.getElementById('o-draw-style-point').classList.add('hidden');
+      break;
+    default:
+      break;
+  }
+  const featureStyle = feature.getStyle();
+  let featureStroke = featureStyle[0].getStroke();
+  let featureFill = featureStyle[0].getFill();
+  const featureText = featureStyle[0].getText();
+  if (featureText) {
+    featureFill = featureText.getFill();
+    featureStroke = featureText.getStroke();
+    const featureTextString = featureText.getText();
+    const featureTextFont = featureText.getFont();
+    const featureTextSize = featureTextFont.split('px')[0];
+    document.getElementById('o-draw-style-textSizeSlider').value = featureTextSize;
+    textSize = featureTextSize;
+    document.getElementById('o-draw-style-textString').value = featureTextString;
+    textString = featureTextString;
+  }
+  if (featureStroke) {
+    const width = featureStroke.getWidth();
+    const lineDash = featureStroke.getLineDash();
+    const featureStrokeColor = featureStroke.getColor();
+    const colorString = `rgb(${featureStrokeColor[0]},${featureStrokeColor[1]},${featureStrokeColor[2]})`;
+    const strokeEl = document.getElementById('o-draw-style-strokeColor');
+    const strokeInputEl = strokeEl.querySelector(`input[value = "${colorString}"]`);
+    if (strokeInputEl) {
+      strokeInputEl.checked = true;
+    } else {
+      const checkedEl = document.querySelector('input[name = "strokeColorRadio"]:checked');
+      if (checkedEl) {
+        checkedEl.checked = false;
+      }
+    }
+    document.getElementById('o-draw-style-strokeWidthSlider').value = width;
+    document.getElementById('o-draw-style-strokeOpacitySlider').value = featureStrokeColor[3];
+    document.getElementById('o-draw-style-strokeType').value = strokeType;
+    strokeWidth = width;
+    strokeOpacity = featureStrokeColor[3];
+    getStrokeType(lineDash);
+    setStrokeColor(colorString);
+  }
+  if (featureFill) {
+    const featureFillColor = featureFill.getColor();
+    const colorString = `rgb(${featureFillColor[0]},${featureFillColor[1]},${featureFillColor[2]})`;
+    const fillEl = document.getElementById('o-draw-style-fillColor');
+    const fillInputEl = fillEl.querySelector(`input[value = "${colorString}"]`);
+    if (fillInputEl) {
+      fillInputEl.checked = true;
+    } else {
+      const checkedEl = document.querySelector('input[name = "fillColorRadio"]:checked');
+      if (checkedEl) {
+        checkedEl.checked = false;
+      }
+    }
+    document.getElementById('o-draw-style-fillOpacitySlider').value = featureFillColor[3];
+    fillOpacity = featureFillColor[3];
+    setFillColor(colorString);
+  }
+}
+
+function getStylewindowStyle(feature) {
+  let geometryType = feature.getGeometry().getType();
+  if (feature.get(annotationField)) {
+    geometryType = 'TextPoint';
+  }
+  const style = [];
+  let lineDash;
+  if (strokeType === 'dash') {
+    lineDash = [3 * strokeWidth, 3 * strokeWidth];
+  } else if (strokeType === 'dash-point') {
+    lineDash = [3 * strokeWidth, 3 * strokeWidth, 0.1, 3 * strokeWidth];
+  } else if (strokeType === 'point') {
+    lineDash = [0.1, 3 * strokeWidth];
+  } else {
+    lineDash = false;
+  }
+
+  const stroke = new Origo.ol.style.Stroke({
+    color: strokeColorArr,
+    width: strokeWidth,
+    lineDash
+  });
+  const fill = new Origo.ol.style.Fill({
+    color: fillColorArr
+  });
+  const font = `${textSize}px ${textFont}`;
+  switch (geometryType) {
+    case 'LineString':
+    case 'MultiLineString':
+      style[0] = new Origo.ol.style.Style({
+        stroke
+      });
+      break;
+    case 'Polygon':
+    case 'MultiPolygon':
+      style[0] = new Origo.ol.style.Style({
+        fill,
+        stroke
+      });
+      break;
+    case 'Point':
+    case 'MultiPoint':
+      style[0] = createRegularShape(pointType, pointSize, fill, stroke);
+      break;
+    case 'TextPoint':
+      style[0] = new Origo.ol.style.Style({
+        text: new Origo.ol.style.Text({
+          text: textString || 'Text',
+          font,
+          fill
+        })
+      });
+      break;
+    default:
+      style[0] = createRegularShape(pointType, pointSize, fill, stroke);
+      break;
+  }
+  return style;
+}
+
+function styleFeature() {
+  drawHandler.getSelection().forEach((feature) => {
+    const style = feature.getStyle();
+    style[0] = getStylewindowStyle(feature)[0];
+    feature.setStyle(style);
+  });
+}
+
+function setInitialValues() {
+  const fillColorEl = document.querySelector('input[name = "fillColorRadio"]:checked');
+  fillColor = fillColorEl ? fillColorEl.value : 'rgb(0,153,255)';
+  fillOpacity = document.getElementById('o-draw-style-fillOpacitySlider').value;
+  fillColorArr = rgbToArray(fillColor, fillOpacity);
+  const strokeColorEl = document.querySelector('input[name = "strokeColorRadio"]:checked');
+  strokeColor = strokeColorEl ? strokeColorEl.value : 'rgb(0,153,255)';
+  strokeOpacity = document.getElementById('o-draw-style-strokeOpacitySlider').value;
+  strokeWidth = document.getElementById('o-draw-style-strokeWidthSlider').value;
+  strokeType = document.getElementById('o-draw-style-strokeType').value;
+  strokeColorArr = rgbToArray(strokeColor, strokeOpacity);
+  pointSize = document.getElementById('o-draw-style-pointSizeSlider').value;
+  pointType = document.getElementById('o-draw-style-pointType').value;
+  textSize = document.getElementById('o-draw-style-textSizeSlider').value;
+  textString = document.getElementById('o-draw-style-textString').value;
+}
+
+function bindUIActions() {
+  let matches;
+  const fillColorEl = document.getElementById('o-draw-style-fillColor');
+  const strokeColorEl = document.getElementById('o-draw-style-strokeColor');
+
+  matches = fillColorEl.querySelectorAll('span');
+  for (let i = 0; i < matches.length; i += 1) {
+    matches[i].addEventListener('click', function e() {
+      setFillColor(this.style.backgroundColor);
+      styleFeature();
+    });
+  }
+
+  matches = strokeColorEl.querySelectorAll('span');
+  for (let i = 0; i < matches.length; i += 1) {
+    matches[i].addEventListener('click', function e() {
+      setStrokeColor(this.style.backgroundColor);
+      styleFeature();
+    });
+  }
+
+  document.getElementById('o-draw-style-fillOpacitySlider').addEventListener('input', function e() {
+    fillOpacity = this.value;
+    setFillColor(fillColor);
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-strokeOpacitySlider').addEventListener('input', function e() {
+    strokeOpacity = this.value;
+    setStrokeColor(strokeColor);
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-strokeWidthSlider').addEventListener('input', function e() {
+    strokeWidth = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-strokeType').addEventListener('change', function e() {
+    strokeType = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-pointType').addEventListener('change', function e() {
+    pointType = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-pointSizeSlider').addEventListener('input', function e() {
+    pointSize = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-textString').addEventListener('input', function e() {
+    textString = this.value;
+    styleFeature();
+  });
+
+  document.getElementById('o-draw-style-textSizeSlider').addEventListener('input', function e() {
+    textSize = this.value;
+    styleFeature();
+  });
+}
+
+function Stylewindow(optOptions = {}) {
+  const {
+    title = 'Anpassa stil',
+    cls = 'control overflow-hidden hidden',
+    target,
+    closeIcon = '#ic_close_24px',
+    style = '',
+    palette = ['rgb(166,206,227)', 'rgb(31,120,180)', 'rgb(178,223,138)', 'rgb(51,160,44)', 'rgb(251,154,153)', 'rgb(227,26,28)', 'rgb(253,191,111)']
+  } = optOptions;
+
+  annotationField = optOptions.annotation || 'annotation';
+
+  let stylewindowEl;
+  let titleEl;
+  let headerEl;
+  let contentEl;
+  let closeButton;
+
+  palette.forEach((item, index) => {
+    const colorArr = rgbToArray(palette[index]);
+    palette[index] = `rgb(${colorArr[0]},${colorArr[1]},${colorArr[2]})`;
+  });
+
+  const closeWindow = function closeWindow() {
+    stylewindowEl.classList.toggle('hidden');
+  };
+
+  return Origo.ui.Component({
+    closeWindow,
+    onInit() {
+      const headerCmps = [];
+
+      titleEl = Origo.ui.Element({
+        cls: 'flex row justify-start margin-y-small margin-left text-weight-bold',
+        style: 'width: 100%;',
+        innerHTML: `${title}`
+      });
+      headerCmps.push(titleEl);
+
+      closeButton = Origo.ui.Button({
+        cls: 'small round margin-top-small margin-right-small margin-bottom-auto margin-right icon-smaller grey-lightest no-shrink',
+        icon: closeIcon,
+        validStates: ['initial', 'hidden'],
+        click() {
+          closeWindow();
+        }
+      });
+      headerCmps.push(closeButton);
+
+      headerEl = Origo.ui.Element({
+        cls: 'flex justify-end grey-lightest',
+        components: headerCmps
+      });
+
+      contentEl = Origo.ui.Element({
+        cls: 'o-draw-stylewindow-content overflow-auto',
+        innerHTML: `${styleTemplate(palette)}`
+      });
+
+      this.addComponent(headerEl);
+      this.addComponent(contentEl);
+
+      this.on('render', this.onRender);
+      document.getElementById(target).appendChild(Origo.ui.dom.html(this.render()));
+      this.dispatch('render');
+      bindUIActions();
+      setInitialValues();
+    },
+    onRender() {
+      stylewindowEl = document.getElementById('o-draw-stylewindow');
+    },
+    render() {
+      let addStyle;
+      if (style !== '') {
+        addStyle = `style="${style}"`;
+      } else {
+        addStyle = '';
+      }
+      return `<div id="o-draw-stylewindow" class="${cls} flex">
+                  <div class="absolute flex column no-margin width-full height-full" ${addStyle}>
+                    ${headerEl.render()}
+                    ${contentEl.render()}
+                  </div>
+                </div>`;
+    }
+  });
+}
+
+export {
+  Stylewindow,
+  restoreStylewindow,
+  updateStylewindow,
+  getStylewindowStyle
+};


### PR DESCRIPTION
Fixes #10 and probably also solves #9 
Adds a new button in the toolbar to style drawn features. 

When loading Origo you can supply an color array like this:
`var origo = Origo('index.json');
origo.on('load', function (viewer) {
var draw = Draw({
buttonText: 'Rita',
drawTools: {
"Polygon": ["freehand"],
"LineString": ["freehand"]
},
palette: ['rgb(166,206,227)','rgb(31,120,180)','rgb(178,223,138)','rgb(51,160,44)','rgb(251,154,153)','rgb(227,26,28)','rgb(253,191,111)','rgb(255,127,0)','rgb(202,178,214)','rgb(106,61,154)','rgb(255,255,153)','rgb(177,89,40)']
});
viewer.addComponent(draw);
});`