### PR TITLE
Add the box-shadow class for better visibility

### DIFF
--- a/src/draw/drawtemplate.js
+++ b/src/draw/drawtemplate.js
@@ -1,39 +1,39 @@
 export default `<div id="o-draw-toolbar" class="o-draw-toolbar o-toolbar o-toolbar-horizontal o-padding-horizontal-8 o-rounded-top o-hidden">
-    <button title="Punkt" id="o-draw-point" class="icon-smaller medium round light" type="button" name="button">
+    <button title="Punkt" id="o-draw-point" class="icon-smaller medium round light box-shadow" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_place_24px"></use>
       </svg>
     </button>
     <div class="o-popover-container">
-      <button title="Polygon" id="o-draw-polygon" class="icon-smaller medium round light" type="button" name="button">
+      <button title="Polygon" id="o-draw-polygon" class="icon-smaller medium round light box-shadow" type="button" name="button">
         <svg class="icon">
           <use xlink:href="#o_polygon_24px"></use>
         </svg>
       </button>
     </div>
     <div class="o-popover-container">
-      <button title="Linje" id="o-draw-polyline" class="icon-smaller medium round light" type="button" name="button">
+      <button title="Linje" id="o-draw-polyline" class="icon-smaller medium round light box-shadow" type="button" name="button">
         <svg class="icon">
           <use xlink:href="#ic_timeline_24px"></use>
         </svg>
       </button>
     </div>
-    <button title="Text" id="o-draw-text" class="icon-smaller medium round light" type="button" name="button">
+    <button title="Text" id="o-draw-text" class="icon-smaller medium round light box-shadow" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_title_24px"></use>
       </svg>
     </button>
-    <button title="Stil" id="o-draw-style" class="icon-smaller medium round light" type="button" name="button">
+    <button title="Stil" id="o-draw-style" class="icon-smaller medium round light box-shadow" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_palette_24px"></use>
       </svg>
     </button>
-    <button title="Ta bort" id="o-draw-delete" class="icon-smaller medium round light" type="button" name="button">
+    <button title="Ta bort" id="o-draw-delete" class="icon-smaller medium round light box-shadow" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_delete_24px"></use>
       </svg>
     </button>
-    <button title="Stäng" id="o-draw-close" class="icon-smaller medium round light" type="button" name="button">
+    <button title="Stäng" id="o-draw-close" class="icon-smaller medium round light box-shadow" type="button" name="button">
       <svg class="icon">
         <use xlink:href="#ic_close_24px"></use>
       </svg>


### PR DESCRIPTION
Fixes #24.

This adds the missing button shadows:

![image](https://user-images.githubusercontent.com/2445979/106019149-9d112300-60c2-11eb-8dd6-34e8dae5cc1a.png)
